### PR TITLE
Change to use actual language code for directory

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
    <meta charset="UTF-8">
@@ -30,7 +30,7 @@
                <a href="https://wiki.sibermerdeka.net">Wiki↪</a>
             </li>
             <li>
-               <a href="#" onclick="switchLanguage('en')"><u>EN</u></a> / <a href="#" onclick="switchLanguage('bm')">BM</a>
+               <a href="#" onclick="switchLanguage('en')"><u>EN</u></a> / <a href="#" onclick="switchLanguage('ms')">BM</a>
             </li>
          </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
             if (browserLang.startsWith('en')) {
                 window.location.href = '/en/';
             } else {
-                window.location.href = '/bm/';
+                window.location.href = '/ms/';
             }
         }
     </script>
@@ -25,6 +25,6 @@
 </head>
 <body>
     <a href="/en/">English</a>
-    <a href="/bm/">Bahasa Malaysia</a>
+    <a href="/ms/">Bahasa Malaysia</a>
 </body>
 </html>

--- a/ms/index.html
+++ b/ms/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ms">
 
 <head>
    <meta charset="UTF-8">
@@ -8,7 +8,7 @@
    <link href="../css/style.css" rel="stylesheet" type="text/css" media="all">
    <link rel="icon" type="image/png" href="https://neothemes.neocities.org/images/favicon.gif" />
    <script>
-      localStorage.setItem('preferredLang', 'bm');
+      localStorage.setItem('preferredLang', 'ms');
 
       function switchLanguage(lang) {
          localStorage.setItem('preferredLang', lang);
@@ -31,7 +31,7 @@
                <a href="https://wiki.vitails.dev">Wiki↪</a>
             </li>
             <li>
-               <a href="#" onclick="switchLanguage('en')">EN</a> / <a href="#" onclick="switchLanguage('bm')"><u>BM</u></a>
+               <a href="#" onclick="switchLanguage('en')">EN</a> / <a href="#" onclick="switchLanguage('ms')"><u>BM</u></a>
             </li>
       </div>
       <div class="wrapper">


### PR DESCRIPTION
As discussed in real life yesterday, I've now made changes to use actual language code for directory
- changed the directory for pages written in Malay from `bm` to `ms` to follow ISO 639 set 1 tags instead of using abbreviation of the language (bm is abbreviation of bahasa melayu / malaysia)
- changed the links and cookie setting to use `ms` instead of `bm`
- also added language tag to the HTML pages so that browser and screen readers would know what language the page is written in

These changes will also make it easier to add more languages in the future when we set the precedence to use ISO language tags instead of coming up with our own directory names